### PR TITLE
Fix: /template 경로만 인터셉터에 등록

### DIFF
--- a/src/main/java/wepik/backend/global/config/WebConfig.java
+++ b/src/main/java/wepik/backend/global/config/WebConfig.java
@@ -29,8 +29,7 @@ public class WebConfig implements WebMvcConfigurer {
                 //todo session 체크하는 경로 지정
                 // 임시로 템플릿 생성만 session 체크
                 registry.addInterceptor(new AuthenticationInterceptor())
-                        .addPathPatterns("/template")
-                        .excludePathPatterns("/**");
+                        .addPathPatterns("/template");
             }
         };
     }


### PR DESCRIPTION
## 💡 작업 내용
- [ ] .excludePathPatterns에 모든 경로를 등록했었는데 제외

## 💡 자세한 설명
/template를 인터셉터 경로에 지정 후 모든 경로를 제외 시켜 결국 모든 경로에 인터셉터가 미적용

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [ ] PR 제목을 형식에 맞게 작성했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [ ] 이슈는 close 했나요?
- [ ] Reviewers, Labels, Projects를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?

closes #이슈번호