### PR TITLE
Fix @ResponseStatus 파라미터에 HttpStatus.OK 추가

### DIFF
--- a/src/main/java/wepik/backend/module/member/presentation/MemberController.java
+++ b/src/main/java/wepik/backend/module/member/presentation/MemberController.java
@@ -49,7 +49,7 @@ public class MemberController {
         return memberService.userLogin(loginRequest, request);
     }
 
-    @ResponseStatus
+    @ResponseStatus(HttpStatus.OK)
     @GetMapping("/session")
     @Operation(summary = "세션ID로 회원 정보 반환", description = "쿠키에 세션ID를 담아 요청하면 해당 세션의 회원 정보를 보내준다.")
     public MemberInfo getSessionMemberInfo(HttpServletRequest request) {


### PR DESCRIPTION
## 💡 작업 내용
- [ ] @ResponseStatus 파라미터에 HttpStatus.OK 추가

## 💡 자세한 설명
@ResponseStatus 어노테이션 사용시 HttpStatus 값을 지정해주지 않으면 500 에러 발생
-> HttpStatus 값 추가

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [ ] PR 제목을 형식에 맞게 작성했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [ ] 이슈는 close 했나요?
- [ ] Reviewers, Labels, Projects를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?

closes #이슈번호