### PR TITLE
Feat: Chat GPT를 활용한 결과 분석

### DIFF
--- a/src/main/java/wepik/backend/global/config/OpenAiConfig.java
+++ b/src/main/java/wepik/backend/global/config/OpenAiConfig.java
@@ -1,0 +1,23 @@
+package wepik.backend.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class OpenAiConfig {
+
+    @Value("${openai.api.key}")
+    private String apiKey;
+
+    @Bean
+    public RestTemplate template(){
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.getInterceptors().add((request, body, execution) -> {
+            request.getHeaders().add("Authorization", "Bearer " + apiKey);
+            return execution.execute(request, body);
+        });
+        return restTemplate;
+    }
+}

--- a/src/main/java/wepik/backend/module/analysis/application/AnalysisService.java
+++ b/src/main/java/wepik/backend/module/analysis/application/AnalysisService.java
@@ -1,0 +1,58 @@
+package wepik.backend.module.analysis.application;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import wepik.backend.module.analysis.dto.AnalysisResult;
+import wepik.backend.module.analysis.dto.GptRequest;
+import wepik.backend.module.analysis.dto.GptResponse;
+import wepik.backend.module.result.application.ResultService;
+
+@Service
+@RequiredArgsConstructor
+public class AnalysisService {
+
+    @Value("${openai.api.url}")
+    private String apiUrl;
+
+    @Value("${openai.api.model}")
+    private String gptModel;
+
+    private final RestTemplate restTemplate;
+
+    private final ResultService resultService;
+
+    private final ObjectMapper objectMapper;
+
+    public AnalysisResult getAnalysis(String senderId, String receiverId) throws JsonProcessingException {
+
+        String prompt = generatePrompt(senderId, receiverId);
+        GptRequest gptRequest = new GptRequest(gptModel, prompt);
+        GptResponse gptResponse = restTemplate.postForObject(apiUrl, gptRequest, GptResponse.class);
+        String content = gptResponse.getChoices().get(0).getMessage().getContent();
+
+        return parseGptResponse(content);
+    }
+
+    private String generatePrompt(String senderId, String receiverId) throws JsonProcessingException {
+        return "templateTitle 주제에 대해서 공통된 질문의 sender와 receiver 답변이 있어 이 두사람이 templateTitle 주제에 얼마나 잘 맞을지 score와 간단한 요약 description 두개만 json으로 나타내줘\n"
+                + objectMapper.writeValueAsString(resultService.loadResult(senderId, receiverId));
+    }
+
+    private AnalysisResult parseGptResponse(String content) {
+        try {
+            Map<String, Object> responseMap = objectMapper.readValue(content, Map.class);
+            int score = (Integer) responseMap.get("score");
+            String description = (String) responseMap.get("description");
+            return new AnalysisResult(score, description);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+}

--- a/src/main/java/wepik/backend/module/analysis/dto/AnalysisResult.java
+++ b/src/main/java/wepik/backend/module/analysis/dto/AnalysisResult.java
@@ -1,0 +1,14 @@
+package wepik.backend.module.analysis.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class AnalysisResult {
+
+    private int score;
+    private String description;
+}

--- a/src/main/java/wepik/backend/module/analysis/dto/GptRequest.java
+++ b/src/main/java/wepik/backend/module/analysis/dto/GptRequest.java
@@ -1,0 +1,18 @@
+package wepik.backend.module.analysis.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class GptRequest {
+
+    private String model;
+    private List<Message> messages;
+
+    public GptRequest(String model, String prompt) {
+        this.model = model;
+        this.messages =  new ArrayList<>();
+        this.messages.add(new Message("user", prompt));
+    }
+}

--- a/src/main/java/wepik/backend/module/analysis/dto/GptResponse.java
+++ b/src/main/java/wepik/backend/module/analysis/dto/GptResponse.java
@@ -1,0 +1,22 @@
+package wepik.backend.module.analysis.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class GptResponse {
+
+    private List<Choice> choices;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Choice {
+        private int index;
+        private Message message;
+    }
+}

--- a/src/main/java/wepik/backend/module/analysis/dto/Message.java
+++ b/src/main/java/wepik/backend/module/analysis/dto/Message.java
@@ -1,0 +1,14 @@
+package wepik.backend.module.analysis.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Message {
+
+    private String role;
+    private String content;
+}

--- a/src/main/java/wepik/backend/module/analysis/presentation/AnalysisController.java
+++ b/src/main/java/wepik/backend/module/analysis/presentation/AnalysisController.java
@@ -1,0 +1,31 @@
+package wepik.backend.module.analysis.presentation;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import wepik.backend.module.analysis.application.AnalysisService;
+import wepik.backend.module.analysis.dto.AnalysisResult;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("analysis")
+@Tag(name = "Analysis", description = "결과 분석 api")
+public class AnalysisController {
+
+    private final AnalysisService analysisService;
+
+    @GetMapping()
+    public AnalysisResult getAnalysis(@RequestParam String senderId, @RequestParam String receiverId) throws JsonProcessingException {
+
+        log.info("uuid : {}, {}", senderId, receiverId);
+        return analysisService.getAnalysis(senderId, receiverId);
+    }
+}


### PR DESCRIPTION
## 💡 작업 내용
- [ ] senderId, receiverId를 받아 result 데이터 조회 후 Chat GPT에게 결과 분석 요청하는 기능
- [ ] GPT 요청 데이터 생성 시 result 데이터를 String으로 만들기 위해 ObjectMapper 사용
- [ ] OpenAiConfig > GPT 요청을 위해 RestTemplate 스프링 빈 등록 시 api key 셋팅
- [ ] analysis > dto는 아래 블로그 글 참고 (GPT 응답 데이터 구조)

## 💡 자세한 설명
(가능한 한 자세히 작성해 주시면 도움이 됩니다.)

## 📗 참고 자료 (선택)
[GPT-Springboot 연동 블로그 글](https://jypark1111.tistory.com/203)

## 📢 리뷰 요구 사항 (선택)
application.yml 추가 필요
```
openai:
    api:
      key: 본인 api key
      url: "https://api.openai.com/v1/chat/completions"
      model: gpt-3.5-turbo
```

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [ ] 이슈는 close 했나요?
- [ ] Reviewers, Labels, Projects를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?

closes #이슈번호